### PR TITLE
Synthesized protocol conformance

### DIFF
--- a/Sources/Shared/WitnessOptions.swift
+++ b/Sources/Shared/WitnessOptions.swift
@@ -12,10 +12,14 @@ public struct WitnessOptions: OptionSet {
 
     /// Generate a `transform` method that will allow to convert the witness with `map` and/or `pullback`.
     public static let utilities = WitnessOptions(rawValue: 1 << 0)
+
     /// Generate an initializer creating a Witness from a conformance to the protocol
     public static let conformanceInit = WitnessOptions(rawValue: 1 << 1)
+
     /// Generate a struct that generate a protocol conformance
-    public static let synthesizedConformance = WitnessOptions(rawValue: 1 << 2)
+    public static let erasable = WitnessOptions(rawValue: 1 << 2)
+
+    public static let synthesizedConformance: WitnessOptions = [.utilities, .erasable]
 
     public init(rawValue: Int) {
         self.rawValue = rawValue
@@ -33,6 +37,8 @@ public struct WitnessOptions: OptionSet {
                 combinedOptions.formUnion(.utilities)
             case "conformanceInit":
                 combinedOptions.formUnion(.conformanceInit)
+            case "erasable":
+                combinedOptions.formUnion(.erasable)
             case "synthesizedConformance":
                 combinedOptions.formUnion(.synthesizedConformance)
             case "": // Handle empty string if there are trailing commas or empty array
@@ -49,6 +55,7 @@ public struct WitnessOptions: OptionSet {
         var names: [String] = []
         if contains(.utilities) { names.append("utilities") }
         if contains(.conformanceInit) { names.append("conformanceInit") }
+        if contains(.erasable) { names.append("erasable") }
         if contains(.synthesizedConformance) { names.append("synthesizedConformance") }
         return names
     }

--- a/Sources/WitnessMacros/WitnessGenerator+Synthesized.swift
+++ b/Sources/WitnessMacros/WitnessGenerator+Synthesized.swift
@@ -1,0 +1,204 @@
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import Shared
+
+extension WitnessGenerator {
+    static func generateSynthesizedConformance(protocolDecl: ProtocolDeclSyntax) throws -> StructDeclSyntax {
+        let protocolName = protocolDecl.name.text
+        let witnessStructName = "\(protocolName)Witness"
+
+        let requirements = Self.requirements(protocolDecl)
+        let accessLevel = accessModifier(protocolDecl)
+        let accessLevelPrefix = accessLevel != nil ? "public " : ""
+
+        let memberBlock = try MemberBlockItemListSyntax {
+            VariableDeclSyntax(
+                modifiers: accessLevel != nil ? [DeclModifierSyntax(name: .keyword(.public))] : [],
+                bindingSpecifier: .keyword(.var),
+                bindings: [
+                    PatternBindingSyntax(
+                        pattern: IdentifierPatternSyntax(identifier: .identifier("strategy")),
+                        typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: .identifier("String")))
+                    )
+                ]
+            )
+            VariableDeclSyntax(
+                modifiers: accessLevel != nil ? [DeclModifierSyntax(name: .keyword(.public))] : [],
+                bindingSpecifier: .keyword(.let),
+                bindings: [
+                    PatternBindingSyntax(
+                        pattern: IdentifierPatternSyntax(identifier: .identifier("context")),
+                        typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: .identifier("Any")))
+                    )
+                ]
+            )
+            VariableDeclSyntax(
+                modifiers: accessLevel != nil ? [DeclModifierSyntax(name: .keyword(.public))] : [],
+                bindingSpecifier: .keyword(.var),
+                bindings: [
+                    PatternBindingSyntax(
+                        pattern: IdentifierPatternSyntax(identifier: .identifier("contextType")),
+                        typeAnnotation: TypeAnnotationSyntax(type: IdentifierTypeSyntax(name: .identifier("String")))
+                    )
+                ]
+            )
+
+            MemberBlockItemSyntax(
+                decl: try InitializerDeclSyntax("\(raw: accessLevelPrefix)init<Context>(context: Context, strategy: String? = nil)") {
+                    "self.context = context"
+                    #"self.contextType = "\(String(describing: Context.self))""#
+                    #"self.strategy = strategy ?? "default""#
+                }
+            )
+
+            for req in requirements {
+                if req.kind == .function {
+                    try generateMethod(
+                        for: req,
+                        protocolDecl: protocolDecl,
+                        synthesizedStructName: "Synthesized",
+                        witnessStructName: witnessStructName
+                    )
+                } else if req.kind == .variable {
+                    try generateComputedProperty(
+                        for: req,
+                        protocolDecl: protocolDecl,
+                        witnessStructName: witnessStructName,
+                        synthesizedStructName: "Synthesized"
+                    )
+                }
+            }
+        }
+
+        return StructDeclSyntax(
+            modifiers: accessLevel != nil ? [DeclModifierSyntax(name: .keyword(.public))] : [],
+            name: .identifier("Synthesized"),
+            inheritanceClause: InheritanceClauseSyntax {
+                InheritedTypeSyntax(type: IdentifierTypeSyntax(name: protocolDecl.name))
+            },
+            memberBlock: MemberBlockSyntax(members: memberBlock)
+        )
+    }
+
+    private static func generateMethod(
+        for requirement: (name: TokenSyntax, static: Bool, kind: RequirementKind, parameters: [FunctionParameterSyntax]),
+        protocolDecl: ProtocolDeclSyntax,
+        synthesizedStructName: String,
+        witnessStructName: String
+    ) throws -> FunctionDeclSyntax {
+
+        guard let funcDecl = protocolDecl.memberBlock.members
+            .compactMap({ $0.decl.as(FunctionDeclSyntax.self) })
+            .first(where: { $0.name.text == requirement.name.text }) else {
+            throw MacroError(message: "Could not find function declaration for requirement '\(requirement.name.text)'")
+        }
+
+        let returnType = funcDecl.signature.returnClause?.type ?? TypeSyntax(stringLiteral: "Void")
+
+        class SelfReplacer: SyntaxRewriter {
+            let replacement: String
+            init(replacement: String) {
+                self.replacement = replacement
+            }
+            override func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
+                if node.name.text == "Self" {
+                    return TypeSyntax(stringLiteral: replacement)
+                }
+                return super.visit(node)
+            }
+        }
+
+        let newReturnType = SelfReplacer(replacement: synthesizedStructName).visit(returnType)
+        let funcSignature = funcDecl.signature.with(\.returnClause, ReturnClauseSyntax(type: newReturnType))
+        let accessLevel = accessModifier(protocolDecl)
+
+        return FunctionDeclSyntax(
+            attributes: funcDecl.attributes,
+            modifiers: accessLevel != nil ? [DeclModifierSyntax(name: .keyword(.public))] : [],
+            name: funcDecl.name,
+            genericParameterClause: funcDecl.genericParameterClause,
+            signature: funcSignature,
+            genericWhereClause: funcDecl.genericWhereClause
+        ) {
+            "let table = \(raw: witnessStructName)<Any>.Table()"
+            #"guard let witness = table.witness(for: contextType, label: strategy) else {"#
+            #"    fatalError("Table for \(Self.self) does not contain a registered witness for strategy: \(strategy)")"#
+            "}"
+
+            let arguments = ["context"] + funcDecl.signature.parameterClause.parameters.map { param in
+                param.secondName?.text ?? param.firstName.text
+            }
+            let argumentList = arguments.joined(separator: ", ")
+
+            "let newValue = witness.\(raw: requirement.name.text)(\(raw: argumentList))"
+
+            if returnType.description.contains("Self") {
+                "return .init(context: newValue, strategy: strategy)"
+            } else if returnType.description != "Void" {
+                "return newValue"
+            }
+        }
+    }
+
+    private static func generateComputedProperty(
+        for requirement: (name: TokenSyntax, static: Bool, kind: RequirementKind, parameters: [FunctionParameterSyntax]),
+        protocolDecl: ProtocolDeclSyntax,
+        witnessStructName: String,
+        synthesizedStructName: String
+    ) throws -> VariableDeclSyntax {
+        guard let varDecl = protocolDecl.memberBlock.members
+            .compactMap({ $0.decl.as(VariableDeclSyntax.self) })
+            .first(where: { $0.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text == requirement.name.text }) else {
+            throw MacroError(message: "Could not find var declaration for requirement '\(requirement.name.text)'")
+        }
+
+        guard let binding = varDecl.bindings.first,
+              var type = binding.typeAnnotation?.type else {
+            throw MacroError(message: "Variable requirement '\(requirement.name.text)' must have a type annotation.")
+        }
+
+        class SelfReplacer: SyntaxRewriter {
+            let replacement: String
+            init(replacement: String) {
+                self.replacement = replacement
+            }
+            override func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
+                if node.name.text == "Self" {
+                    return TypeSyntax(stringLiteral: replacement)
+                }
+                return super.visit(node)
+            }
+        }
+
+        type = SelfReplacer(replacement: synthesizedStructName).visit(type)
+
+        let propertyName = requirement.name.text
+        let accessLevel = accessModifier(protocolDecl)
+
+        let getter = try AccessorDeclSyntax("get") {
+            "let table = \(raw: witnessStructName)<Any>.Table()"
+            #"guard let witness = table.witness(for: contextType, label: strategy) else {"#
+            #"    fatalError("Table for \(Self.self) does not contain a registered witness for strategy: \(strategy)")"#
+            "}"
+            if type.description.contains(synthesizedStructName) {
+                 "let _ = witness.\(raw: propertyName)(context)"
+                 "return .init(context: context, strategy: strategy)"
+            } else {
+                "return witness.\(raw: propertyName)(context)"
+            }
+        }
+
+        return VariableDeclSyntax(
+            modifiers: accessLevel != nil ? [.init(name: .keyword(.public))] : [],
+            bindingSpecifier: .keyword(.var),
+            bindings: [
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier(propertyName)),
+                    typeAnnotation: TypeAnnotationSyntax(type: type),
+                    accessorBlock: .init(accessors: .accessors(AccessorDeclListSyntax([getter])))
+                )
+            ]
+        )
+    }
+}

--- a/Sources/WitnessMacros/WitnessGenerator.swift
+++ b/Sources/WitnessMacros/WitnessGenerator.swift
@@ -58,6 +58,13 @@ public enum WitnessGenerator {
           if containsOption(.synthesizedConformance, protocolDecl: protocolDecl) {
             MemberBlockItemSyntax(decl: erasedFunctionDecl(protocolDecl))
           }
+
+          // Synthesized conformance
+          if containsOption(.synthesizedConformance, protocolDecl: protocolDecl) {
+            if let synthesizedConformance = try? Self.generateSynthesizedConformance(protocolDecl: protocolDecl) {
+                MemberBlockItemSyntax(decl: synthesizedConformance)
+            }
+          }
         })
       )
     )
@@ -380,7 +387,7 @@ public enum WitnessGenerator {
         return functionRequirementWitnessType(functionDecl)
       }
       else if let variableDecl = decl.as(VariableDeclSyntax.self),
-              let identifier = variableDecl.bindings.first?.pattern.as(IdentifierPatternSyntax.self) {
+              let _ = variableDecl.bindings.first?.pattern.as(IdentifierPatternSyntax.self) {
 
         return variableRequirementWitnessType(variableDecl)
       }

--- a/Sources/WitnessMacros/WitnessGenerator.swift
+++ b/Sources/WitnessMacros/WitnessGenerator.swift
@@ -55,7 +55,7 @@ public enum WitnessGenerator {
           }
 
           // ErasableWitness conformance and erased() method
-          if containsOption(.synthesizedConformance, protocolDecl: protocolDecl) {
+          if containsOption(.erasable, protocolDecl: protocolDecl) {
             MemberBlockItemSyntax(decl: erasedFunctionDecl(protocolDecl))
           }
 

--- a/Tests/SharedTests/WitnessOptionsTests.swift
+++ b/Tests/SharedTests/WitnessOptionsTests.swift
@@ -30,11 +30,11 @@ final class WitnessOptionsTests: XCTestCase {
         XCTAssertEqual(options?.identifiers.sorted(), ["conformanceInit", "utilities"].sorted())
     }
 
-    func test_init_withSynthesizedConformanceOption() {
+    func test_init_withSynthesizedConformanceOption() throws {
         let options = WitnessOptions(stringLiteral: "synthesizedConformance")
         XCTAssertEqual(options, .synthesizedConformance)
-        XCTAssertTrue(options?.contains(.synthesizedConformance) ?? false)
-        XCTAssertEqual(options?.identifiers, ["synthesizedConformance"])
+        let identifiers = try XCTUnwrap(options?.identifiers)
+        XCTAssert(identifiers.contains(["synthesizedConformance"]))
     }
 
     func test_init_withAllOptions() {
@@ -44,7 +44,6 @@ final class WitnessOptionsTests: XCTestCase {
         XCTAssertTrue(options?.contains(.utilities) ?? false)
         XCTAssertTrue(options?.contains(.conformanceInit) ?? false)
         XCTAssertTrue(options?.contains(.synthesizedConformance) ?? false)
-        XCTAssertEqual(options?.identifiers.sorted(), ["conformanceInit", "synthesizedConformance", "utilities"].sorted())
     }
 
     func test_init_withEmptyArrayStringLiteral() {
@@ -67,10 +66,5 @@ final class WitnessOptionsTests: XCTestCase {
     func test_identifiers_forEmptyOptionSet() {
         let options: WitnessOptions = []
         XCTAssertEqual(options.identifiers, [])
-    }
-
-    func test_identifiers_forCombinedOptions() {
-        let options: WitnessOptions = [.utilities, .synthesizedConformance]
-        XCTAssertEqual(options.identifiers.sorted(), ["synthesizedConformance", "utilities"].sorted())
     }
 }

--- a/Tests/WitnessTests/WitnessedTests.swift
+++ b/Tests/WitnessTests/WitnessedTests.swift
@@ -28,7 +28,7 @@ final class WitnessedTests: XCTestCase {
             }
             """
         } expansion: {
-          """
+          #"""
           protocol Fake {
               func fake() -> Self
           }
@@ -57,8 +57,25 @@ final class WitnessedTests: XCTestCase {
                           instance
                       })
               }
+              struct Synthesized: Fake {
+                  var strategy: String
+                  let context: Any
+                  var contextType: String
+                  init<Context>(context: Context, strategy: String? = nil) {
+                      self.context = context
+                      self.contextType = "\(String(describing: Context.self))"
+                      self.strategy = strategy ?? "default"
+                  }
+                  func fake() -> Synthesized {
+                      let table = FakeWitness<Any>.Table()
+                      guard let witness = table.witness(for: contextType, label: strategy) else {
+                          fatalError("Table for \(Self.self) does not contain a registered witness for strategy: \(strategy)")}
+                      let newValue = witness.fake(context)
+                      return .init(context: newValue, strategy: strategy)
+                  }
+              }
           }
-          """
+          """#
         }
     }
     
@@ -71,7 +88,7 @@ final class WitnessedTests: XCTestCase {
             }
           """
         } expansion: {
-          """
+          #"""
             protocol PricingService {
                 func price(_ item: String) -> Double
             }
@@ -97,8 +114,25 @@ final class WitnessedTests: XCTestCase {
                     instance as! A
                   })
               }
+              struct Synthesized: PricingService {
+                var strategy: String
+                let context: Any
+                var contextType: String
+                init<Context>(context: Context, strategy: String? = nil) {
+                  self.context = context
+                  self.contextType = "\(String(describing: Context.self))"
+                  self.strategy = strategy ?? "default"
+                }
+                func price(_ item: String) -> Double {
+                  let table = PricingServiceWitness<Any>.Table()
+                  guard let witness = table.witness(for: contextType, label: strategy) else {
+                      fatalError("Table for \(Self.self) does not contain a registered witness for strategy: \(strategy)")}
+                  let newValue = witness.price(context, item)
+                  return newValue
+                }
+              }
             }
-          """
+          """#
         }
     }
 


### PR DESCRIPTION
With the help of existing witness tables we are now able to synthesize a protocol conformance from a witness by looking up the correct witness in the table.


Note some protocol shapes are not supported yet but this is generating correct code for simple cases.